### PR TITLE
Hotfix: Fix the link for the `add to server` button for /about

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.danielvm'
-version = '0.2.0-alpha'
+version = '0.2.1-alpha'
 
 
 java {

--- a/src/main/java/com/deahtstroke/rivenbot/handler/about/AboutHandler.java
+++ b/src/main/java/com/deahtstroke/rivenbot/handler/about/AboutHandler.java
@@ -1,6 +1,5 @@
 package com.deahtstroke.rivenbot.handler.about;
 
-import static com.deahtstroke.rivenbot.util.MessageUtils.BOT_INVITE_LINK;
 import static com.deahtstroke.rivenbot.util.MessageUtils.DISCORD_SERVER;
 import static com.deahtstroke.rivenbot.util.MessageUtils.GITHUB_REPO;
 import static com.deahtstroke.rivenbot.util.MessageUtils.ICON_URL;
@@ -17,6 +16,7 @@ import com.deahtstroke.rivenbot.enums.SlashCommand;
 import com.deahtstroke.rivenbot.handler.SlashCommandHandler;
 import com.deahtstroke.rivenbot.util.MessageComponents;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -25,9 +25,12 @@ import reactor.core.publisher.Mono;
 public class AboutHandler implements SlashCommandHandler {
 
   private final BuildProperties buildProperties;
+  private final String inviteLink;
 
-  public AboutHandler(BuildProperties buildProperties) {
+  public AboutHandler(BuildProperties buildProperties,
+      @Value("${application.inviteLink}") String inviteLink) {
     this.buildProperties = buildProperties;
+    this.inviteLink = inviteLink;
   }
 
   @Override
@@ -76,7 +79,7 @@ public class AboutHandler implements SlashCommandHandler {
                     """)
                 .build()))
         .footer(EmbeddedFooter.builder()
-            .text("Current Version %s:%s".formatted(buildProperties.getName(),
+            .text("Current Version: %s:%s".formatted(buildProperties.getName(),
                 buildProperties.getVersion()))
             .build())
         .build();
@@ -85,7 +88,7 @@ public class AboutHandler implements SlashCommandHandler {
         .embeds(List.of(aboutEmbed))
         .components(MessageComponents.components()
             .addActionRow(MessageComponents.actionRow()
-                .linkButton("Add to Server", BOT_INVITE_LINK))
+                .linkButton("Add to Server", inviteLink))
             .build())
         .build();
     return Mono.just(InteractionResponse.builder()

--- a/src/main/java/com/deahtstroke/rivenbot/util/MessageUtils.java
+++ b/src/main/java/com/deahtstroke/rivenbot/util/MessageUtils.java
@@ -16,7 +16,6 @@ public class MessageUtils {
   public static final String ICON_URL = "https://ih1.redbubble.net/image.2953200665.7291/st,small,507x507-pad,600x600,f8f8f8.jpg";
   public static final String GITHUB_REPO = "https://github.com/dvillavicencio/riven-bot";
   public static final String DISCORD_SERVER = "https://discord.gg/yMShmXQs";
-  public static final String BOT_INVITE_LINK = "https://discord.com/oauth2/authorize?client_id=1109351854934065213&permissions=274877966400&integration_type=0&scope=bot";
 
   private static final LocalTime DESTINY_2_STANDARD_RESET_TIME = LocalTime.of(9, 0);
   private static final ZoneId STANDARD_TIMEZONE = ZoneId.of("America/Los_Angeles");

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,6 +6,7 @@ spring:
       host: localhost
 
 application:
+  inviteLink: https://discord.com/oauth2/authorize?client_id=1109351854934065213&permissions=274877966400&integration_type=0&scope=bot
   callback:
     # Replace with your own callback url masking port 8080 to run locally
     url: https://c797-2600-1700-4390-a930-95a3-1de8-fb35-181.ngrok-free.app

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,5 +6,6 @@ spring:
       host: mongo
 
 application:
+  inviteLink: https://discord.com/oauth2/authorize?client_id=1177030727678820362&permissions=274877966400&integration_type=0&scope=bot
   callback:
     url: https://rivenbot.app

--- a/src/test/java/com/deahtstroke/rivenbot/handler/about/AboutHandlerTest.java
+++ b/src/test/java/com/deahtstroke/rivenbot/handler/about/AboutHandlerTest.java
@@ -96,7 +96,7 @@ class AboutHandlerTest {
 
           EmbeddedFooter footer = firstEmbedded.getFooter();
           assertThat(footer.getText()).isEqualTo(
-              "Current Version %s:%s".formatted(buildProperties.getName(),
+              "Current Version: %s:%s".formatted(buildProperties.getName(),
                   buildProperties.getVersion()));
 
           List<MessageComponent> components = data.getComponents();

--- a/src/test/java/com/deahtstroke/rivenbot/handler/about/AboutHandlerTest.java
+++ b/src/test/java/com/deahtstroke/rivenbot/handler/about/AboutHandlerTest.java
@@ -1,9 +1,9 @@
 package com.deahtstroke.rivenbot.handler.about;
 
-import static com.deahtstroke.rivenbot.util.MessageUtils.BOT_INVITE_LINK;
 import static com.deahtstroke.rivenbot.util.MessageUtils.DISCORD_SERVER;
 import static com.deahtstroke.rivenbot.util.MessageUtils.GITHUB_REPO;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.deahtstroke.rivenbot.dto.discord.Embedded;
@@ -13,13 +13,11 @@ import com.deahtstroke.rivenbot.dto.discord.Interaction;
 import com.deahtstroke.rivenbot.dto.discord.InteractionResponseData;
 import com.deahtstroke.rivenbot.dto.discord.MessageComponent;
 import com.deahtstroke.rivenbot.enums.InteractionResponseType;
-import com.deahtstroke.rivenbot.handler.about.AboutHandler;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.info.BuildProperties;
 import reactor.test.StepVerifier;
@@ -27,11 +25,17 @@ import reactor.test.StepVerifier;
 @ExtendWith(MockitoExtension.class)
 class AboutHandlerTest {
 
-  @Mock
+  String inviteLink = "https://discord.invite.link.for.bot/";
+
   BuildProperties buildProperties;
 
-  @InjectMocks
   AboutHandler sut;
+
+  @BeforeEach
+  void setup() {
+    buildProperties = mock(BuildProperties.class);
+    sut = new AboutHandler(buildProperties, inviteLink);
+  }
 
   @Test
   @DisplayName("Serving a request is successful")
@@ -105,7 +109,7 @@ class AboutHandlerTest {
           assertThat(linkButton.getType()).isEqualTo(2);
           assertThat(linkButton.getLabel()).isEqualTo("Add to Server");
           assertThat(linkButton.getStyle()).isEqualTo(5);
-          assertThat(linkButton.getUrl()).isEqualTo(BOT_INVITE_LINK);
+          assertThat(linkButton.getUrl()).isEqualTo(inviteLink);
         }).verifyComplete();
   }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,3 +37,6 @@ cache:
   expirations:
     playersPrefixSearch: 5
     manifestEntity: 3600
+
+application:
+  inviteLink: https://some.invite.link


### PR DESCRIPTION
There was a slight oversight when building the /about command. The `Add to Server` button had hardcoded the local variant of the bot. With this change, now there's an environment-specific link for the button.