### PR TITLE
Hotfix: Re-added Discord installation link as invite link in /about command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.danielvm'
-version = '0.2.1-alpha'
+version = '0.2.2-alpha'
 
 
 java {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,6 +6,6 @@ spring:
       host: mongo
 
 application:
-  inviteLink: https://discord.com/oauth2/authorize?client_id=1177030727678820362&permissions=274877966400&integration_type=0&scope=bot
+  inviteLink: https://discord.com/oauth2/authorize?client_id=1177030727678820362
   callback:
     url: https://rivenbot.app


### PR DESCRIPTION
There was an unexpected change in Discord's way to manage installation for applications in their portal. Now the invite link does not need to have all the permissions embedded in the link but then it internalizes it to the app itself. This change just adds a hotfix to resolve the `Installation not supported` issue.